### PR TITLE
fix: add node-fetch dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.58
+
+- fix: add `node-fetch` dependency
+
 ## 0.0.57
 
 - feat(adapter): add URI FileStore

--- a/libs/adapter/package.json
+++ b/libs/adapter/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@pl-oss/adapter",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "license": "MIT"
 }

--- a/libs/domain/package.json
+++ b/libs/domain/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@pl-oss/domain",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "license": "MIT"
 }

--- a/libs/vue/package.json
+++ b/libs/vue/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@pl-oss/vue",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@eventstore/db-client": "^1.2.1",
     "@nestjs/common": "^7.6.18",
     "mongodb": "^3.6.8",
+    "node-fetch": "^2.6.1",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.0.0",
     "vue": "^2.6.11",


### PR DESCRIPTION
We already had node-fetch in `yarn.lock` so nothing was breaking.
Maybe it was lingering on from any other dependency or history.